### PR TITLE
Sender public key in transaction info API.

### DIFF
--- a/scorex-transaction/src/main/scala/scorex/transaction/PaymentTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/PaymentTransaction.scala
@@ -30,6 +30,7 @@ case class PaymentTransaction(sender: PublicKeyAccount,
 
   override lazy val json: JsObject = jsonBase() ++ Json.obj(
     "sender" -> sender.address,
+    "senderPublicKey" -> Base58.encode(sender.publicKey),
     "recipient" -> recipient.address,
     "amount" -> amount
   )


### PR DESCRIPTION
From now on transaction info request will report public key. Yay!
```
{
  "type": 2,
  "fee": 100000,
  "timestamp": 1474360460235,
  "signature": "34H6H9YWbvyJ2jGJjMQsvcawiavUdDLTPJXzFnZBRd1kECrzseRtMQZyeQQQBmbap7MtAbph4rQjorV8abCNtpHb",
  "sender": "3MtCKcpwnQvK2fiVWsKJAhVEpXuFFopDqeE",
  "senderPublicKey": "6to8fRZo4hpuucrehGzc8cXLhuUsWnM7fypsdAZaHuLG",
  "recipient": "3N1p6WWHpg4xeH42zNNv7SF64xj32x3sh7k",
  "amount": 1000000000,
  "height": 142448
}
```
:-)