### PR TITLE
Removed Base58 from walletSeed in settings.json

### DIFF
--- a/scorex-basics/src/main/scala/scorex/settings/Settings.scala
+++ b/scorex-basics/src/main/scala/scorex/settings/Settings.scala
@@ -131,7 +131,7 @@ trait Settings extends ScorexLogging {
     println("Please type your wallet password")
     scala.io.StdIn.readLine()
   }
-  lazy val walletSeed = (settingsJSON \ "walletSeed").asOpt[String].flatMap(s => Base58.decode(s).toOption)
+  lazy val walletSeed = (settingsJSON \ "walletSeed").asOpt[String].flatMap(s => Some(s.getBytes("utf-8")))
 
   lazy val apiKeyHash = (settingsJSON \ "apiKeyHash").asOpt[String].flatMap(s => Base58.decode(s).toOption)
 

--- a/scorex-basics/src/main/scala/scorex/transaction/FeesStateChange.scala
+++ b/scorex-basics/src/main/scala/scorex/transaction/FeesStateChange.scala
@@ -2,6 +2,7 @@ package scorex.transaction
 
 import com.google.common.primitives.Longs
 
+@SerialVersionUID(-8850164212397152939L)
 case class FeesStateChange(fee: Long) extends StateChangeReason {
   override def bytes: Array[Byte] = Longs.toByteArray(fee)
 

--- a/scorex-basics/src/main/scala/scorex/wallet/Wallet.scala
+++ b/scorex-basics/src/main/scala/scorex/wallet/Wallet.scala
@@ -41,12 +41,7 @@ class Wallet(walletFileOpt: Option[File], password: String, seedOpt: Option[Arra
           println(s"You random generated seed is $encodedSeed")
           randomSeed
         } else
-          Base58.decode(typed).getOrElse {
-            if (limit > 0) {
-              println("Wallet seed should be correct Base58 encoded string.")
-              readSeed(limit - 1)
-            } else throw new Error("Sorry you have made too many incorrect seed guesses")
-          }
+          typed.getBytes("utf-8")
       }
       readSeed()
     }

--- a/scorex-transaction/src/main/scala/scorex/api/http/WalletApiRoute.scala
+++ b/scorex-transaction/src/main/scala/scorex/api/http/WalletApiRoute.scala
@@ -26,7 +26,7 @@ case class WalletApiRoute(application: Application)(implicit val context: ActorR
     path("wallet" / "seed") {
       withAuth {
         getJsonRoute {
-          lazy val response = JsonResponse(Json.obj("seed" -> Base58.encode(wallet.seed)), StatusCodes.OK)
+          lazy val response = JsonResponse(Json.obj("seed" -> new String(wallet.seed)), StatusCodes.OK)
           walletNotExists(wallet).getOrElse(response)
         }
       }

--- a/scorex-transaction/src/main/scala/scorex/transaction/GenesisTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/GenesisTransaction.scala
@@ -10,7 +10,7 @@ import scorex.transaction.TypedTransaction.TransactionType
 
 import scala.util.{Failure, Try}
 
-
+@SerialVersionUID(4259636843622212366L)
 case class GenesisTransaction(override val recipient: Account,
                               override val amount: Long,
                               override val timestamp: Long)

--- a/scorex-transaction/src/main/scala/scorex/transaction/LagonakiTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/LagonakiTransaction.scala
@@ -9,7 +9,7 @@ import scorex.transaction.TypedTransaction.TransactionType
 
 import scala.concurrent.duration._
 
-
+@SerialVersionUID(6117785013396482802L)
 abstract class LagonakiTransaction(val transactionType: TransactionType.Value,
                                    val recipient: Account,
                                    val amount: Long,

--- a/scorex-transaction/src/main/scala/scorex/transaction/TypedTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/TypedTransaction.scala
@@ -15,6 +15,7 @@ trait TypedTransaction extends Transaction {
 object TypedTransaction extends Deser[TypedTransaction] {
 
   //TYPES
+  @SerialVersionUID(-5089886728560175625L)
   object TransactionType extends Enumeration {
     val GenesisTransaction = Value(1)
     val PaymentTransaction = Value(2)

--- a/scorex-transaction/src/main/scala/scorex/transaction/assets/IssueTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/assets/IssueTransaction.scala
@@ -14,6 +14,7 @@ import scala.util.Try
 /*
  TODO: Remove assetIdOpt after Testnet relaunch
  */
+@SerialVersionUID(-28455548758206564L)
 case class IssueTransaction(sender: PublicKeyAccount,
                             assetIdOpt: Option[Array[Byte]],
                             name: Array[Byte],

--- a/scorex-transaction/src/main/scala/scorex/transaction/assets/TransferTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/assets/TransferTransaction.scala
@@ -12,6 +12,7 @@ import scorex.transaction._
 
 import scala.util.Try
 
+@SerialVersionUID(7819822579806392886L)
 case class TransferTransaction(assetId: Option[AssetId],
                                sender: PublicKeyAccount,
                                recipient: Account,

--- a/src/test/scala/scorex/lagonaki/integration/api/WalletAPISpecification.scala
+++ b/src/test/scala/scorex/lagonaki/integration/api/WalletAPISpecification.scala
@@ -1,7 +1,6 @@
 package scorex.lagonaki.integration.api
 
 import org.scalatest.{FunSuite, Matchers}
-import scorex.crypto.encode.Base58
 import scorex.lagonaki.integration.TestLock
 
 class WalletAPISpecification extends FunSuite with TestLock with Matchers {
@@ -16,6 +15,6 @@ class WalletAPISpecification extends FunSuite with TestLock with Matchers {
     GET.incorrectApiKeyTest("/wallet/seed")
 
     val response = GET.request("/wallet/seed", headers =  Map("api_key" -> "test"))
-    (response \ "seed").as[String] shouldBe Base58.encode(application.settings.walletSeed.get)
+    (response \ "seed").as[String] shouldBe application.settings.walletSeed.get
   }
 }


### PR DESCRIPTION
Fix for https://github.com/wavesplatform/Waves/issues/41
Web wallet uses seeds based on normal strings. Node uses Base58 strings for the same purpose.
Thus, it makes sense to remove Base58'ing of seed from the Node for the sake of consistency.
