### PR TITLE
[critical] Changed generatingBalanceDepth to 1440.

### DIFF
--- a/scorex-consensus/src/main/scala/scorex/consensus/nxt/NxtLikeConsensusModule.scala
+++ b/scorex-consensus/src/main/scala/scorex/consensus/nxt/NxtLikeConsensusModule.scala
@@ -28,7 +28,7 @@ with OneGeneratorConsensusModule with ScorexLogging {
   val MaxBaseTarget = Long.MaxValue / avgDelayInSeconds
   val InitialBaseTarget = MaxBaseTarget / 2
 
-  override val generatingBalanceDepth = 50
+  override val generatingBalanceDepth = 1440
 
   private def avgDelayInSeconds: Long = AvgDelay.toSeconds
 


### PR DESCRIPTION
Fix for https://github.com/wavesplatform/Waves/issues/42
50 is completely insecure and _will_ lead to the network dying.
I'd like to harden this further [look at the issue for details], but that's after we start the mainnet.