### PR TITLE
Encrypted and unencrypted message transactions.

### DIFF
--- a/lock.sbt
+++ b/lock.sbt
@@ -21,7 +21,7 @@ dependencyOverrides in ThisBuild ++= Set(
   "com.github.swagger-akka-http" % "swagger-akka-http_2.11" % "0.7.2",
   "com.google.code.findbugs" % "annotations" % "2.0.1",
   "com.google.code.findbugs" % "jsr305" % "2.0.1",
-  "com.google.guava" % "guava" % "18.0",
+  "com.google.guava" % "guava" % "19.0",
   "com.h2database" % "h2-mvstore" % "1.4.192",
   "com.ning" % "async-http-client" % "1.9.11",
   "com.thoughtworks.paranamer" % "paranamer" % "2.6",
@@ -56,7 +56,7 @@ dependencyOverrides in ThisBuild ++= Set(
   "org.apache.commons" % "commons-lang3" % "3.2.1",
   "org.bitlet" % "weupnp" % "0.1.4",
   "org.codehaus.woodstox" % "stax2-api" % "3.1.4",
-  "org.consensusresearch" % "scrypto_2.11" % "1.0.4",
+  "org.consensusresearch" % "scrypto_2.11" % "1.2.0-RC2",
   "org.javassist" % "javassist" % "3.18.2-GA",
   "org.joda" % "joda-convert" % "1.7",
   "org.mapdb" % "mapdb" % "2.0-beta13",
@@ -75,9 +75,9 @@ dependencyOverrides in ThisBuild ++= Set(
   "org.scalatest" % "scalatest_2.11" % "2.3.0-SNAP2",
   "org.scoverage" % "scalac-scoverage-plugin_2.11" % "1.1.1",
   "org.scoverage" % "scalac-scoverage-runtime_2.11" % "1.1.1",
-  "org.slf4j" % "slf4j-api" % "1.7.20",
+  "org.slf4j" % "slf4j-api" % "1.7.21",
   "org.typelevel" % "macro-compat_2.11" % "1.1.1",
   "org.whispersystems" % "curve25519-java" % "0.2.4",
   "org.yaml" % "snakeyaml" % "1.12"
 )
-// LIBRARY_DEPENDENCIES_HASH d8360823e14a31a396176de16d9ed659d4187871
+// LIBRARY_DEPENDENCIES_HASH 58f76535b8db4d57d79545ab961b5d70fb915322

--- a/scorex-basics/build.sbt
+++ b/scorex-basics/build.sbt
@@ -11,6 +11,6 @@ libraryDependencies ++=
     Dependencies.testKit ++
     Dependencies.db ++
     Dependencies.logging ++ Seq(
-      "org.consensusresearch" %% "scrypto" % "1.0.4",
+      "org.consensusresearch" %% "scrypto" % "1.2.0-RC2",
       "commons-net" % "commons-net" % "3.+"
   )

--- a/scorex-basics/src/main/scala/scorex/api/http/ApiRoute.scala
+++ b/scorex-basics/src/main/scala/scorex/api/http/ApiRoute.scala
@@ -4,9 +4,9 @@ import akka.actor.ActorRefFactory
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCode}
 import akka.http.scaladsl.server.{Directive0, Directives, Route}
+import scorex.crypto.hash.SecureCryptographicHash.Digest
 import akka.util.Timeout
 import play.api.libs.json.JsValue
-import scorex.crypto.hash.CryptographicHash.Digest
 import scorex.crypto.hash.SecureCryptographicHash
 import scorex.settings.Settings
 

--- a/scorex-basics/src/main/scala/scorex/crypto/EllipticCurveImpl.scala
+++ b/scorex-basics/src/main/scala/scorex/crypto/EllipticCurveImpl.scala
@@ -1,15 +1,21 @@
 package scorex.crypto
 
 import scorex.account.PrivateKeyAccount
-import scorex.crypto.singing.Curve25519
-import scorex.crypto.singing.SigningFunctions.{MessageToSign, Signature}
+import scorex.crypto.signatures.SigningFunctions._
 
-/**
-  * This implementation is being used from many places in the code. We consider easy switching from one
-  * EC implementation from another as possible option, while switching to some other signature schemes
-  * (e.g. hash-based signatures) will require a lot of code changes around the project(at least because of
-  * big signature size).
-  */
-object EllipticCurveImpl extends Curve25519 {
-  def sign(account: PrivateKeyAccount, message: MessageToSign): Signature = sign(account.privateKey, message)
+object EllipticCurveImpl {
+  private val c = scorex.crypto.signatures.Curve25519
+
+  val SignatureLength = c.SignatureLength
+  val KeyLength = c.KeyLength
+
+  def createKeyPair(seed: Array[Byte]): (PrivateKey, PublicKey) = c.createKeyPair(seed)
+
+  def sign(account: PrivateKeyAccount, message: MessageToSign): Signature = c.sign(account.privateKey, message)
+
+  def sign(privateKey: PrivateKey, message: MessageToSign): Signature = c.sign(privateKey, message)
+
+  def verify(signature: Signature, message: MessageToSign, publicKey: PublicKey): Boolean = c.verify(signature, message, publicKey)
+
+  def createSharedSecret(privateKey: PrivateKey, publicKey: PublicKey): SharedSecret = c.createSharedSecret(privateKey, publicKey)
 }

--- a/scorex-basics/src/main/scala/scorex/crypto/hash/FastCryptographicHash.scala
+++ b/scorex-basics/src/main/scala/scorex/crypto/hash/FastCryptographicHash.scala
@@ -1,7 +1,6 @@
 package scorex.crypto.hash
 
 import com.typesafe.config.ConfigFactory
-import scorex.crypto.hash.CryptographicHash._
 import scorex.utils._
 
 import scala.util.Try

--- a/scorex-basics/src/main/scala/scorex/crypto/hash/ScorexHashChain.scala
+++ b/scorex-basics/src/main/scala/scorex/crypto/hash/ScorexHashChain.scala
@@ -1,8 +1,6 @@
 package scorex.crypto.hash
 
 import scorex.crypto._
-import scorex.crypto.hash.CryptographicHash._
-
 
 /**
   * The chain of two hash functions, Blake and Keccak

--- a/scorex-basics/src/main/scala/scorex/crypto/hash/SecureCryptographicHash.scala
+++ b/scorex-basics/src/main/scala/scorex/crypto/hash/SecureCryptographicHash.scala
@@ -1,7 +1,6 @@
 package scorex.crypto.hash
 
 import com.typesafe.config.ConfigFactory
-import scorex.crypto.hash.CryptographicHash._
 import scorex.utils._
 
 import scala.util.Try

--- a/scorex-basics/src/main/scala/scorex/network/message/BasicMessagesRepo.scala
+++ b/scorex-basics/src/main/scala/scorex/network/message/BasicMessagesRepo.scala
@@ -7,8 +7,8 @@ import com.google.common.primitives.{Bytes, Ints}
 import scorex.block.Block
 import scorex.consensus.ConsensusModule
 import scorex.crypto.EllipticCurveImpl
-import scorex.crypto.singing.SigningFunctions
-import scorex.crypto.singing.SigningFunctions.Signature
+import scorex.crypto.signatures.SigningFunctions
+import scorex.crypto.signatures.SigningFunctions.Signature
 import scorex.network.{BlockCheckpoint, Checkpoint}
 import scorex.network.message.Message._
 import scorex.transaction.{History, TransactionModule}

--- a/scorex-basics/src/main/scala/scorex/serialization/BytesSerializable.scala
+++ b/scorex-basics/src/main/scala/scorex/serialization/BytesSerializable.scala
@@ -1,10 +1,12 @@
 package scorex.serialization
 
-import com.google.common.primitives.Ints
+import com.google.common.primitives.{Ints, Shorts}
 
 trait BytesSerializable extends Serializable {
 
   def bytes: Array[Byte]
 
   protected def arrayWithSize(b: Array[Byte]): Array[Byte] = Ints.toByteArray(b.length) ++ b
+
+  protected def arrayWithSize16bit(b: Array[Byte]): Array[Byte] = Shorts.toByteArray(b.length.toShort) ++ b
 }

--- a/scorex-basics/src/main/scala/scorex/serialization/Deser.scala
+++ b/scorex-basics/src/main/scala/scorex/serialization/Deser.scala
@@ -1,6 +1,6 @@
 package scorex.serialization
 
-import com.google.common.primitives.Ints
+import com.google.common.primitives.{Ints, Shorts}
 import scorex.crypto.EllipticCurveImpl._
 
 import scala.util.Try
@@ -15,6 +15,11 @@ trait Deser[T] {
   protected def parseArraySize(bytes: Array[Byte], position: Int): (Array[Byte], Int) = {
     val length = Ints.fromByteArray(bytes.slice(position, position + 4))
     (bytes.slice(position + 4, position + 4 + length), position + 4 + length)
+  }
+
+  protected def parseArraySize16bit(bytes: Array[Byte], position: Int): (Array[Byte], Int) = {
+    val length = Shorts.fromByteArray(bytes.slice(position, position + 2))
+    (bytes.slice(position + 2, position + 2 + length), position + 2 + length)
   }
 
   protected def parseOption(bytes: Array[Byte], position: Int, length: Int): (Option[Array[Byte]], Int) = {

--- a/scorex-basics/src/main/scala/scorex/serialization/JsonSerializable.scala
+++ b/scorex-basics/src/main/scala/scorex/serialization/JsonSerializable.scala
@@ -1,8 +1,12 @@
 package scorex.serialization
 
 import play.api.libs.json.JsObject
+import scorex.wallet.Wallet
 
 trait JsonSerializable {
 
   def json: JsObject
+
+  // This function is executed when the API key is specified. It decrypts messages automatically.
+  def jsonWithWallet(wallet: Wallet): JsObject = json
 }

--- a/scorex-basics/src/main/scala/scorex/transaction/FeesStateChange.scala
+++ b/scorex-basics/src/main/scala/scorex/transaction/FeesStateChange.scala
@@ -2,6 +2,7 @@ package scorex.transaction
 
 import com.google.common.primitives.Longs
 
+@SerialVersionUID(-8850164212397152939L)
 case class FeesStateChange(fee: Long) extends StateChangeReason {
   override def bytes: Array[Byte] = Longs.toByteArray(fee)
 

--- a/scorex-transaction/src/main/scala/scorex/api/http/MessageApiRoute.scala
+++ b/scorex-transaction/src/main/scala/scorex/api/http/MessageApiRoute.scala
@@ -1,0 +1,121 @@
+package scorex.api.http
+
+import javax.ws.rs.Path
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
+import io.swagger.annotations._
+import play.api.libs.json.{JsError, JsSuccess, Json}
+import scorex.transaction._
+import scorex.transaction.state.wallet.{EncryptedMessageTx, MessageTx}
+
+import scala.util.{Failure, Success, Try}
+import akka.actor.ActorRefFactory
+import io.swagger.annotations.{ApiImplicitParam, ApiImplicitParams, ApiOperation}
+import scorex.app.RunnableApplication
+
+@Path("/message")
+@Api(value = "/message")
+case class MessageApiRoute(application: RunnableApplication)(implicit val context: ActorRefFactory)
+  extends ApiRoute with CommonTransactionApiFunctions {
+  val settings = application.settings
+  lazy val wallet = application.wallet
+
+  override lazy val route = pathPrefix("message") {
+    sendMessage ~ sendEncryptedMessage
+  }
+  private implicit val transactionModule = application.transactionModule.asInstanceOf[SimpleTransactionModule]
+
+  @Path("/send")
+  @ApiOperation(value = "Send message",
+    notes = "Send a message through the blockchain",
+    httpMethod = "POST",
+    produces = "application/json",
+    consumes = "application/json")
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(
+      name = "body",
+      value = "Json with data",
+      required = true,
+      paramType = "body",
+      dataType = "scorex.transaction.state.wallet.MessageTx",
+      defaultValue = "{\n\t\"message\":\"Message to send\",\n\t\"fee\":10000,\n\t\"sender\":\"senderId\",\n\t\"recipient\":\"recipientId\"\n}"
+    )
+  ))
+  @ApiResponses(Array(
+    new ApiResponse(code = 200, message = "Json with response or error")
+  ))
+  def sendMessage: Route = path("send") {
+    entity(as[String]) { body =>
+      withAuth {
+        postJsonRoute {
+          walletNotExists(wallet).getOrElse {
+            Try(Json.parse(body)).map { js =>
+              js.validate[MessageTx] match {
+                case err: JsError =>
+                  WrongTransactionJson(err).response
+                case JsSuccess(message: MessageTx, _) =>
+                  val txOpt: Try[MessageTransaction] = transactionModule.sendMessage(message, wallet)
+                  txOpt match {
+                    case Success(tx) =>
+                      JsonResponse(tx.json, StatusCodes.OK)
+                    case Failure(e: StateCheckFailed) =>
+                      StateCheckFailed.response
+                    case _ =>
+                      WrongJson.response
+                  }
+              }
+            }.getOrElse(WrongJson.response)
+          }
+        }
+      }
+    }
+  }
+
+
+  @Path("/send-encrypted")
+  @ApiOperation(value = "Send encrypted message",
+    notes = "Send an encrypted message through the blockchain",
+    httpMethod = "POST",
+    produces = "application/json",
+    consumes = "application/json")
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(
+      name = "body",
+      value = "Json with data",
+      required = true,
+      paramType = "body",
+      dataType = "scorex.transaction.state.wallet.EncryptedMessageTx",
+      defaultValue = "{\n\t\"message\":\"Message to send\",\n\t\"fee\":10000,\n\t\"sender\":\"senderId\",\n\t\"recipientPublicKey\":\"recipientId\"\n}"
+    )
+  ))
+  @ApiResponses(Array(
+    new ApiResponse(code = 200, message = "Json with response or error")
+  ))
+  def sendEncryptedMessage: Route = path("send-encrypted") {
+    entity(as[String]) { body =>
+      withAuth {
+        postJsonRoute {
+          walletNotExists(wallet).getOrElse {
+            Try(Json.parse(body)).map { js =>
+              js.validate[EncryptedMessageTx] match {
+                case err: JsError =>
+                  WrongTransactionJson(err).response
+                case JsSuccess(message: EncryptedMessageTx, _) =>
+                  val txOpt: Try[EncryptedMessageTransaction] = transactionModule.sendEncryptedMessage(message, wallet)
+                  txOpt match {
+                    case Success(tx) =>
+                      JsonResponse(tx.jsonWithWallet(wallet), StatusCodes.OK)
+                    case Failure(e: StateCheckFailed) =>
+                      StateCheckFailed.response
+                    case _ =>
+                      WrongJson.response
+                  }
+              }
+            }.getOrElse(WrongJson.response)
+          }
+        }
+      }
+    }
+  }
+}

--- a/scorex-transaction/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
+++ b/scorex-transaction/src/main/scala/scorex/api/http/TransactionsApiRoute.scala
@@ -27,7 +27,7 @@ case class TransactionsApiRoute(application: Application)(implicit val context: 
 
   override lazy val route =
     pathPrefix("transactions") {
-      unconfirmed ~ addressLimit ~ info
+      unconfirmed ~ addressLimit ~ info ~ decrypt
     }
 
   //TODO implement general pagination
@@ -73,6 +73,37 @@ case class TransactionsApiRoute(application: Application)(implicit val context: 
             }
           case _ => JsonResponse(Json.obj("status" -> "error", "details" -> "Incorrect signature"),
             StatusCodes.UnprocessableEntity)
+        }
+      }
+    }
+  }
+
+  @Path("/decrypt/{signature}")
+  @ApiOperation(value = "Decrypt", notes = "Get decrypted transaction info", httpMethod = "GET")
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(name = "signature", value = "transaction signature ", required = true, dataType = "string", paramType = "path")
+  ))
+  def decrypt: Route = {
+    path("decrypt" / Segment) { case encoded =>
+      withAuth {
+        getJsonRoute {
+          Base58.decode(encoded) match {
+            case Success(sig) =>
+              state.included(sig, None) match {
+                case Some(h) =>
+                  Try {
+                    val block = application.blockStorage.history.asInstanceOf[StoredBlockchain].blockAt(h).get
+                    val tx = block.transactions.filter(_.id sameElements sig).head
+                    val json = tx.jsonWithWallet(application.wallet) + ("height" -> Json.toJson(h))
+                    JsonResponse(json, StatusCodes.OK)
+                  }.getOrElse(JsonResponse(Json.obj("status" -> "error", "details" -> "Internal error"),
+                    StatusCodes.InternalServerError))
+                case None => JsonResponse(Json.obj("status" -> "error", "details" -> "Transaction is not in blockchain"),
+                  StatusCodes.NotFound)
+              }
+            case _ => JsonResponse(Json.obj("status" -> "error", "details" -> "Incorrect signature"),
+              StatusCodes.UnprocessableEntity)
+          }
         }
       }
     }

--- a/scorex-transaction/src/main/scala/scorex/transaction/EncryptedMessageTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/EncryptedMessageTransaction.scala
@@ -116,7 +116,7 @@ case class EncryptedMessageTransaction(timestamp: Long,
       ValidationResult.NonceLengthIncorrect
     } else if (!messageHashValid) {
       ValidationResult.MessageHashInvalid
-    } else if (!signatureValid) {
+    } else if (!signatureWithIdValid) {
       ValidationResult.InvalidSignature
     } else ValidationResult.ValidateOke
   }
@@ -160,7 +160,7 @@ object EncryptedMessageTransaction extends Deser[EncryptedMessageTransaction] {
     lazy val rawMessageHash = Blake2b256.hash(Bytes.concat(nonce, rawMessage)).slice(0, 20)
 
     val unsigned = EncryptedMessageTransaction(timestamp, sender, recipient, feeAmount, rawMessage, rawMessageHash, nonce, null)
-    val sig = EllipticCurveImpl.sign(sender, unsigned.toSign)
+    val sig = EllipticCurveImpl.sign(sender, Array(unsigned.transactionType.id.toByte) ++ unsigned.toSign)
     unsigned.copy(signature = sig)
   }
 
@@ -208,7 +208,7 @@ object EncryptedMessageTransaction extends Deser[EncryptedMessageTransaction] {
     val (rawMessage, rawMessageHash, nonce) = encryptMessage(timestamp, sender, recipient, message)
 
     val unsigned = EncryptedMessageTransaction(timestamp, sender, recipient, feeAmount, rawMessage, rawMessageHash, nonce, null)
-    val sig = EllipticCurveImpl.sign(sender, unsigned.toSign)
+    val sig = EllipticCurveImpl.sign(sender, Array(unsigned.transactionType.id.toByte) ++ unsigned.toSign)
     unsigned.copy(signature = sig)
   }
 }

--- a/scorex-transaction/src/main/scala/scorex/transaction/EncryptedMessageTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/EncryptedMessageTransaction.scala
@@ -1,0 +1,214 @@
+package scorex.transaction
+
+import java.nio.ByteBuffer
+
+import com.google.common.primitives.{Bytes, Longs}
+import play.api.libs.json.{JsObject, Json}
+import scorex.account.{Account, PrivateKeyAccount, PublicKeyAccount}
+import scorex.crypto.EllipticCurveImpl
+import scorex.crypto.encode.{Base58, Base64}
+import scorex.crypto.hash.Blake2b256
+import scorex.serialization.Deser
+import scorex.transaction.TypedTransaction.TransactionType
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.spec.{IvParameterSpec, SecretKeySpec}
+
+import scorex.wallet.Wallet
+
+import scala.util.Try
+
+@SerialVersionUID(1871481793487177171L)
+case class EncryptedMessageTransaction(timestamp: Long,
+                                       sender: PublicKeyAccount,
+                                       recipient: PublicKeyAccount,
+                                       feeAmount: Long,
+                                       rawMessage: Array[Byte],
+                                       rawMessageHash: Array[Byte],
+                                       nonce: Array[Byte],
+                                       signature: Array[Byte]
+                                      ) extends SignedTransaction {
+
+  override val transactionType: TransactionType.Value = TransactionType.EncryptedMessageTransaction
+
+  override val assetFee: (Option[AssetId], Long) = (None, feeAmount)
+
+  def decrypt(wallet: Wallet): Option[Array[Byte]] = {
+    val timestampArray = ByteBuffer.allocate(java.lang.Long.SIZE / java.lang.Byte.SIZE).putLong(timestamp).array()
+
+    var sharedSecret = Array[Byte]()
+    val senderAccount = wallet.privateKeyAccount(Account.fromPublicKey(sender.publicKey).address)
+    if(senderAccount.isDefined)
+      sharedSecret = EllipticCurveImpl.createSharedSecret(senderAccount.get.privateKey, recipient.publicKey)
+    else {
+      val recipientAccount = wallet.privateKeyAccount(Account.fromPublicKey(recipient.publicKey).address)
+      if(recipientAccount.isDefined)
+        sharedSecret = EllipticCurveImpl.createSharedSecret(recipientAccount.get.privateKey, sender.publicKey)
+    }
+    if (sharedSecret.isEmpty)
+      return None
+    val encryptionKey = Blake2b256.hash(Bytes.concat(sharedSecret, timestampArray, nonce)).slice(0, 16)
+    val iv = Blake2b256.hash(encryptionKey).slice(0, 16)
+
+    val cipher: Cipher = Cipher.getInstance("AES/CFB8/NoPadding")
+    val secretKeySpec = new SecretKeySpec(encryptionKey, "AES")
+    cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, new IvParameterSpec(iv))
+    val rawDecryptedMessage = cipher.update(rawMessage)
+
+    val padding = rawDecryptedMessage.apply(0)
+    Some(rawDecryptedMessage.slice(1, rawDecryptedMessage.length - padding))
+  }
+
+  lazy val toSign: Array[Byte] = {
+    val timestampBytes = Longs.toByteArray(timestamp)
+    val feeBytes = Longs.toByteArray(feeAmount)
+
+    Bytes.concat(sender.publicKey, recipient.publicKey, timestampBytes, feeBytes, rawMessageHash)
+  }
+  lazy val notToSign: Array[Byte] = Bytes.concat(nonce, arrayWithSize16bit(rawMessage))
+
+  override lazy val json: JsObject = Json.obj(
+    "type" -> transactionType.id,
+    "id" -> Base58.encode(id),
+    "sender" -> sender.address,
+    "senderPublicKey" -> Base58.encode(sender.publicKey),
+    "recipient" -> recipient.address,
+    "recipientPublicKey" -> Base58.encode(recipient.publicKey),
+    "fee" -> feeAmount,
+    "nonce" -> Base58.encode(nonce),
+    "rawMessage" -> Base58.encode(rawMessage),
+    "rawMessageHash" -> Base58.encode(rawMessageHash),
+    "size" -> bytes.length,
+    "signature" -> Base58.encode(signature),
+    "encrypted" -> true
+  )
+
+  override def jsonWithWallet(wallet: Wallet): JsObject = {
+    val message = decrypt(wallet)
+    if (message.isDefined)
+      json ++ Json.obj("message" -> Base58.encode(message.get))
+    else
+      json
+  }
+
+  override def balanceChanges(): Seq[BalanceChange] = {
+    Seq(BalanceChange(AssetAcc(sender, None), -feeAmount))
+  }
+
+  override lazy val bytes: Array[Byte] = Bytes.concat(Array(transactionType.id.toByte), signature, toSign, notToSign)
+
+  // 160 bits is secure enough for our needs
+  lazy val messageHashValid = java.util.Arrays.equals(Blake2b256.hash(Bytes.concat(nonce, rawMessage)).slice(0, 20), rawMessageHash)
+
+  def validate: ValidationResult.Value = {
+    val l = EllipticCurveImpl.verify(signature, toSign, sender.publicKey)
+    if (!Account.isValid(sender)) {
+      ValidationResult.InvalidAddress
+    } else if (feeAmount <= 0) {
+      ValidationResult.InsufficientFee
+    } else if (rawMessage.length > EncryptedMessageTransaction.MaxMessageSize + EncryptedMessageTransaction.VanityHeaderSize) {
+      ValidationResult.MessageTooLong
+    } else if (rawMessage.length <= EncryptedMessageTransaction.VanityHeaderSize) {
+      ValidationResult.MessageEmpty
+    } else if ((rawMessage.length - EncryptedMessageTransaction.VanityHeaderSize) % EncryptedMessageTransaction.MessageAlign != 0) {
+      ValidationResult.MessageNotAligned
+    } else if (nonce.length != EncryptedMessageTransaction.NonceLength) {
+      ValidationResult.NonceLengthIncorrect
+    } else if (!messageHashValid) {
+      ValidationResult.MessageHashInvalid
+    } else if (!signatureValid) {
+      ValidationResult.InvalidSignature
+    } else ValidationResult.ValidateOke
+  }
+}
+
+object EncryptedMessageTransaction extends Deser[EncryptedMessageTransaction] {
+
+  val MaxMessageSize = 256
+  val VanityHeaderSize = 1
+  val MessageAlign = 32
+  val NonceLength = 8
+
+  override def parseBytes(bytes: Array[Byte]): Try[EncryptedMessageTransaction] = Try {
+    require(bytes.head == TransactionType.EncryptedMessageTransaction.id)
+    parseTail(bytes.tail).get
+  }
+
+  def parseTail(bytes: Array[Byte]): Try[EncryptedMessageTransaction] = Try {
+    import EllipticCurveImpl._
+    val signature = bytes.slice(0, SignatureLength)
+    val sender = new PublicKeyAccount(bytes.slice(SignatureLength, SignatureLength + KeyLength))
+    val s0 = SignatureLength + KeyLength
+    val recipient = new PublicKeyAccount(bytes.slice(s0, s0 + KeyLength))
+    val s1 = s0 + KeyLength
+    val timestamp = Longs.fromByteArray(bytes.slice(s1, s1 + 8))
+    val feeAmount = Longs.fromByteArray(bytes.slice(s1 + 8, s1 + 16))
+    val rawMessageHash = bytes.slice(s1 + 16, s1 + 16 + 20)
+    val s2 = s1 + 16 + 20
+    val nonce = bytes.slice(s2, s2 + NonceLength)
+    val (rawMessage, _) = parseArraySize16bit(bytes, s2 + NonceLength)
+    EncryptedMessageTransaction(timestamp, sender, recipient, feeAmount, rawMessage, rawMessageHash, nonce, signature)
+  }
+
+  def create(timestamp: Long,
+             sender: PrivateKeyAccount,
+             recipient: PublicKeyAccount,
+             feeAmount: Long,
+             rawMessage: Array[Byte],
+             nonce: Array[Byte]
+            ): EncryptedMessageTransaction = {
+    lazy val rawMessageHash = Blake2b256.hash(Bytes.concat(nonce, rawMessage)).slice(0, 20)
+
+    val unsigned = EncryptedMessageTransaction(timestamp, sender, recipient, feeAmount, rawMessage, rawMessageHash, nonce, null)
+    val sig = EllipticCurveImpl.sign(sender, unsigned.toSign)
+    unsigned.copy(signature = sig)
+  }
+
+  private def makeNonce(): Array[Byte] = {
+    val rand = new SecureRandom()
+    val seed = Array.fill[Byte](NonceLength)(0)
+    rand.nextBytes(seed)
+    seed
+  }
+
+  private def encryptMessage(timestamp: Long,
+                             sender: PrivateKeyAccount,
+                             recipient: PublicKeyAccount,
+                             message: Array[Byte]): (Array[Byte], Array[Byte], Array[Byte]) = {
+    val rand = new SecureRandom()
+    val nonce = makeNonce()
+    val timestampArray = ByteBuffer.allocate(java.lang.Long.SIZE / java.lang.Byte.SIZE).putLong(timestamp).array()
+
+    val padding = MessageAlign - (message.length % MessageAlign)
+    val paddingRandom = Array.fill[Byte](padding)(0)
+    rand.nextBytes(paddingRandom)
+
+    val rawDecryptedMessage = Array[Byte](padding.toByte) ++ message ++ paddingRandom
+
+    val sharedSecret = EllipticCurveImpl.createSharedSecret(sender.privateKey, recipient.publicKey)
+    val encryptionKey = Blake2b256.hash(Bytes.concat(sharedSecret, timestampArray, nonce)).slice(0, 16)
+    val iv = Blake2b256.hash(encryptionKey).slice(0, 16)
+
+    val cipher: Cipher = Cipher.getInstance("AES/CFB8/NoPadding")
+    val secretKeySpec = new SecretKeySpec(encryptionKey, "AES")
+    cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, new IvParameterSpec(iv))
+    val rawMessage = cipher.update(rawDecryptedMessage)
+
+    val rawMessageHash = Blake2b256.hash(Bytes.concat(nonce, rawMessage)).slice(0, 20)
+
+    (rawMessage, rawMessageHash, nonce)
+  }
+
+  def createAndEncrypt(timestamp: Long,
+             sender: PrivateKeyAccount,
+             recipient: PublicKeyAccount,
+             feeAmount: Long,
+             message: Array[Byte]
+            ): EncryptedMessageTransaction = {
+    val (rawMessage, rawMessageHash, nonce) = encryptMessage(timestamp, sender, recipient, message)
+
+    val unsigned = EncryptedMessageTransaction(timestamp, sender, recipient, feeAmount, rawMessage, rawMessageHash, nonce, null)
+    val sig = EllipticCurveImpl.sign(sender, unsigned.toSign)
+    unsigned.copy(signature = sig)
+  }
+}

--- a/scorex-transaction/src/main/scala/scorex/transaction/GenesisTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/GenesisTransaction.scala
@@ -10,7 +10,7 @@ import scorex.transaction.TypedTransaction.TransactionType
 
 import scala.util.{Failure, Try}
 
-
+@SerialVersionUID(4259636843622212366L)
 case class GenesisTransaction(override val recipient: Account,
                               override val amount: Long,
                               override val timestamp: Long)

--- a/scorex-transaction/src/main/scala/scorex/transaction/LagonakiTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/LagonakiTransaction.scala
@@ -9,7 +9,7 @@ import scorex.transaction.TypedTransaction.TransactionType
 
 import scala.concurrent.duration._
 
-
+@SerialVersionUID(6117785013396482802L)
 abstract class LagonakiTransaction(val transactionType: TransactionType.Value,
                                    val recipient: Account,
                                    val amount: Long,

--- a/scorex-transaction/src/main/scala/scorex/transaction/MessageTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/MessageTransaction.scala
@@ -1,0 +1,111 @@
+package scorex.transaction
+
+import com.google.common.primitives.{Bytes, Longs}
+import play.api.libs.json.{JsObject, Json}
+import scorex.account.{Account, PrivateKeyAccount, PublicKeyAccount}
+import scorex.crypto.EllipticCurveImpl
+import scorex.crypto.encode.Base58
+import scorex.serialization.Deser
+import scorex.transaction.TypedTransaction.TransactionType
+import scorex.crypto.hash.Blake2b256
+
+import scala.util.Try
+
+@SerialVersionUID(1739417897630221966L)
+case class MessageTransaction(timestamp: Long,
+                              sender: PublicKeyAccount,
+                              recipient: Account,
+                              fee: Long,
+                              message: Array[Byte],
+                              messageHash: Array[Byte],
+                              signature: Array[Byte]
+                             ) extends SignedTransaction {
+
+  override val transactionType: TransactionType.Value = TransactionType.MessageTransaction
+
+  override val assetFee: (Option[AssetId], Long) = (None, fee)
+
+  lazy val toSign: Array[Byte] = {
+    val timestampBytes = Longs.toByteArray(timestamp)
+    val feeBytes = Longs.toByteArray(fee)
+
+    Bytes.concat(sender.publicKey, timestampBytes, feeBytes, recipient.bytes, messageHash)
+  }
+  lazy val notToSign: Array[Byte] = arrayWithSize16bit(message)
+
+  override lazy val json: JsObject = Json.obj(
+    "type" -> transactionType.id,
+    "id" -> Base58.encode(id),
+    "sender" -> sender.address,
+    "senderPublicKey" -> Base58.encode(sender.publicKey),
+    "recipient" -> recipient.address,
+    "fee" -> fee,
+    "message" -> Base58.encode(message),
+    "messageHash" -> Base58.encode(messageHash),
+    "size" -> bytes.length,
+    "signature" -> Base58.encode(signature),
+    "encrypted" -> false
+  )
+
+  override def balanceChanges(): Seq[BalanceChange] = {
+    Seq(BalanceChange(AssetAcc(sender, None), -fee))
+  }
+
+  override lazy val bytes: Array[Byte] = Bytes.concat(Array(transactionType.id.toByte), signature, toSign, notToSign)
+
+  // 160 bits is secure enough for our needs
+  lazy val messageHashValid = messageHash == Blake2b256.hash(message).slice(0, 20)
+
+  def validate: ValidationResult.Value =
+    if (!Account.isValid(sender)) {
+      ValidationResult.InvalidAddress
+    } else if (fee <= 0) {
+      ValidationResult.InsufficientFee
+    } else if (message.length > MessageTransaction.MaxMessageSize) {
+      ValidationResult.MessageTooLong
+    } else if (message.length == 0) {
+      ValidationResult.MessageEmpty
+    } else if (!signatureValid) {
+      ValidationResult.InvalidSignature
+    } else if (messageHashValid) {
+      ValidationResult.MessageHashInvalid
+    } else ValidationResult.ValidateOke
+
+}
+
+object MessageTransaction extends Deser[MessageTransaction] {
+
+  val MaxMessageSize = 256
+
+  override def parseBytes(bytes: Array[Byte]): Try[MessageTransaction] = Try {
+    require(bytes.head == TransactionType.MessageTransaction.id)
+    parseTail(bytes.tail).get
+  }
+
+  def parseTail(bytes: Array[Byte]): Try[MessageTransaction] = Try {
+    import EllipticCurveImpl._
+    val signature = bytes.slice(0, SignatureLength)
+    val sender = new PublicKeyAccount(bytes.slice(SignatureLength, SignatureLength + KeyLength))
+    val s0 = SignatureLength + KeyLength
+    val timestamp = Longs.fromByteArray(bytes.slice(s0, s0 + 8))
+    val feeAmount = Longs.fromByteArray(bytes.slice(s0 + 8, s0 + 16))
+    val recipient = new Account(Base58.encode(bytes.slice(s0 + 16, s0 + 16 + Account.AddressLength)))
+    val s1 = s0 + 16 + Account.AddressLength
+    val messageHash = bytes.slice(s1, s1 + 20)
+    val (message, _) = parseArraySize16bit(bytes, s1 + 20)
+    MessageTransaction(timestamp, sender, recipient, feeAmount, message, messageHash, signature)
+  }
+
+  def create(timestamp: Long,
+             sender: PrivateKeyAccount,
+             recipient: Account,
+             feeAmount: Long,
+             message: Array[Byte]): MessageTransaction = {
+    // 160 bits is surely secure enough for our needs
+    lazy val messageHash = Blake2b256.hash(message).slice(0, 20)
+
+    val unsigned = MessageTransaction(timestamp, sender, recipient, feeAmount, message, messageHash, null)
+    val sig = EllipticCurveImpl.sign(sender, unsigned.toSign)
+    unsigned.copy(signature = sig)
+  }
+}

--- a/scorex-transaction/src/main/scala/scorex/transaction/MessageTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/MessageTransaction.scala
@@ -65,7 +65,7 @@ case class MessageTransaction(timestamp: Long,
       ValidationResult.MessageTooLong
     } else if (message.length == 0) {
       ValidationResult.MessageEmpty
-    } else if (!signatureValid) {
+    } else if (!signatureWithIdValid) {
       ValidationResult.InvalidSignature
     } else if (messageHashValid) {
       ValidationResult.MessageHashInvalid
@@ -105,7 +105,7 @@ object MessageTransaction extends Deser[MessageTransaction] {
     lazy val messageHash = Blake2b256.hash(message).slice(0, 20)
 
     val unsigned = MessageTransaction(timestamp, sender, recipient, feeAmount, message, messageHash, null)
-    val sig = EllipticCurveImpl.sign(sender, unsigned.toSign)
+    val sig = EllipticCurveImpl.sign(sender, Array(unsigned.transactionType.id.toByte) ++ unsigned.toSign)
     unsigned.copy(signature = sig)
   }
 }

--- a/scorex-transaction/src/main/scala/scorex/transaction/SignedTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/SignedTransaction.scala
@@ -10,6 +10,7 @@ trait SignedTransaction extends TypedTransaction {
   val signature: Array[Byte]
   val sender: PublicKeyAccount
   protected lazy val signatureValid = EllipticCurveImpl.verify(signature, toSign, sender.publicKey)
+  protected lazy val signatureWithIdValid = EllipticCurveImpl.verify(signature, Array(transactionType.id.toByte) ++ toSign, sender.publicKey)
   override lazy val id: Array[Byte] = FastCryptographicHash(toSign)
 
   def validate: ValidationResult.Value

--- a/scorex-transaction/src/main/scala/scorex/transaction/TransactionSettings.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/TransactionSettings.scala
@@ -24,7 +24,9 @@ trait TransactionSettings {
     TransactionAssetFee(2, None).key -> 100000,
     TransactionAssetFee(3, None).key -> 100000,
     TransactionAssetFee(4, None).key -> 100000,
-    TransactionAssetFee(5, None).key -> 100000
+    TransactionAssetFee(5, None).key -> 100000,
+    TransactionAssetFee(6, None).key -> 100000,
+    TransactionAssetFee(7, None).key -> 100000
   )
 
 

--- a/scorex-transaction/src/main/scala/scorex/transaction/TypedTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/TypedTransaction.scala
@@ -15,12 +15,15 @@ trait TypedTransaction extends Transaction {
 object TypedTransaction extends Deser[TypedTransaction] {
 
   //TYPES
+  @SerialVersionUID(-5089886728560175625L)
   object TransactionType extends Enumeration {
     val GenesisTransaction = Value(1)
     val PaymentTransaction = Value(2)
     val IssueTransaction = Value(3)
     val TransferTransaction = Value(4)
     val ReissueTransaction = Value(5)
+    val MessageTransaction = Value(6)
+    val EncryptedMessageTransaction = Value(7)
   }
 
   def parseBytes(data: Array[Byte]): Try[TypedTransaction] =
@@ -39,6 +42,12 @@ object TypedTransaction extends Deser[TypedTransaction] {
 
       case txType: Byte if txType == TransactionType.ReissueTransaction.id =>
         ReissueTransaction.parseTail(data.tail)
+
+      case txType: Byte if txType == TransactionType.MessageTransaction.id =>
+        MessageTransaction.parseTail(data.tail)
+
+      case txType: Byte if txType == TransactionType.EncryptedMessageTransaction.id =>
+        EncryptedMessageTransaction.parseTail(data.tail)
 
       case txType => Failure(new Exception(s"Invalid transaction type: $txType"))
     }

--- a/scorex-transaction/src/main/scala/scorex/transaction/ValidationResult.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/ValidationResult.scala
@@ -13,4 +13,9 @@ object ValidationResult extends Enumeration {
   val InvalidName = Value(8)
   val StateCheckFailed = Value(9)
   val OverflowError = Value(10)
+  val MessageEmpty = Value(11)
+  val MessageTooLong = Value(12)
+  val MessageHashInvalid = Value(13)
+  val MessageNotAligned = Value(14)
+  val NonceLengthIncorrect = Value(15)
 }

--- a/scorex-transaction/src/main/scala/scorex/transaction/assets/IssueTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/assets/IssueTransaction.scala
@@ -14,6 +14,7 @@ import scala.util.Try
 /*
  TODO: Remove assetIdOpt after Testnet relaunch
  */
+@SerialVersionUID(-28455548758206564L)
 case class IssueTransaction(sender: PublicKeyAccount,
                             assetIdOpt: Option[Array[Byte]],
                             name: Array[Byte],

--- a/scorex-transaction/src/main/scala/scorex/transaction/assets/TransferTransaction.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/assets/TransferTransaction.scala
@@ -12,6 +12,7 @@ import scorex.transaction._
 
 import scala.util.Try
 
+@SerialVersionUID(7819822579806392886L)
 case class TransferTransaction(assetId: Option[AssetId],
                                sender: PublicKeyAccount,
                                recipient: Account,

--- a/scorex-transaction/src/main/scala/scorex/transaction/state/database/blockchain/StoredState.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/state/database/blockchain/StoredState.scala
@@ -330,6 +330,10 @@ class StoredState(db: MVStore) extends LagonakiState with ScorexLogging {
         sameSender && reissuable
       }
       reissueValid && tx.validate == ValidationResult.ValidateOke && included(tx.id, None).isEmpty
+    case tx: MessageTransaction =>
+      tx.validate == ValidationResult.ValidateOke && included(tx.id, None).isEmpty
+    case tx: EncryptedMessageTransaction =>
+      tx.validate == ValidationResult.ValidateOke && included(tx.id, None).isEmpty
     case gtx: GenesisTransaction =>
       height == 0
     case otx: Any =>

--- a/scorex-transaction/src/main/scala/scorex/transaction/state/wallet/EncryptedMessageTx.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/state/wallet/EncryptedMessageTx.scala
@@ -1,0 +1,23 @@
+package scorex.transaction.state.wallet
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Reads, Writes}
+
+case class EncryptedMessageTx(fee: Long, sender: String, recipientPublicKey: String, message: String)
+
+object EncryptedMessageTx {
+  implicit val messageWrites: Writes[EncryptedMessageTx] = (
+    (JsPath \ "fee").write[Long] and
+      (JsPath \ "sender").write[String] and
+      (JsPath \ "recipientPublicKey").write[String] and
+      (JsPath \ "message").write[String]
+    ) (unlift(EncryptedMessageTx.unapply))
+
+  implicit val messageReads: Reads[EncryptedMessageTx] = (
+    (JsPath \ "fee").read[Long] and
+      (JsPath \ "sender").read[String] and
+      (JsPath \ "recipientPublicKey").read[String] and
+      (JsPath \ "message").read[String]
+    ) (EncryptedMessageTx.apply _)
+
+}

--- a/scorex-transaction/src/main/scala/scorex/transaction/state/wallet/MessageTx.scala
+++ b/scorex-transaction/src/main/scala/scorex/transaction/state/wallet/MessageTx.scala
@@ -1,0 +1,23 @@
+package scorex.transaction.state.wallet
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Reads, Writes}
+
+case class MessageTx(fee: Long, sender: String, recipient: String, message: String)
+
+object MessageTx {
+  implicit val messageWrites: Writes[MessageTx] = (
+    (JsPath \ "fee").write[Long] and
+      (JsPath \ "sender").write[String] and
+      (JsPath \ "recipient").write[String] and
+      (JsPath \ "message").write[String]
+    ) (unlift(MessageTx.unapply))
+
+  implicit val messageReads: Reads[MessageTx] = (
+    (JsPath \ "fee").read[Long] and
+      (JsPath \ "sender").read[String] and
+      (JsPath \ "recipient").read[String] and
+      (JsPath \ "message").read[String]
+    ) (MessageTx.apply _)
+
+}

--- a/scorex-transaction/src/test/scala/scorex/transaction/EncryptedMessageTransactionSpecification.scala
+++ b/scorex-transaction/src/test/scala/scorex/transaction/EncryptedMessageTransactionSpecification.scala
@@ -1,0 +1,79 @@
+package scorex.transaction
+
+import org.scalacheck.Gen
+import org.scalatest._
+import org.scalatest.prop.PropertyChecks
+import scorex.account.PrivateKeyAccount
+import scorex.crypto.encode.Base58
+import scorex.wallet.Wallet
+
+class EncryptedMessageTransactionSpecification extends PropSpec with PropertyChecks with Matchers with TransactionGen {
+
+  def genRandomMessage(): Gen[Array[Byte]] = {
+    val mul = scala.util.Random.nextInt(4) + 1
+    genBoundedBytes(1 + mul * 32, 1 + mul * 32)
+  }
+
+  val rawEncryptedMessageGenerator: Gen[EncryptedMessageTransaction] = for {
+    sender: PrivateKeyAccount <- accountGen
+    recipient: PrivateKeyAccount <- accountGen
+    raw_message <- genRandomMessage()
+    nonce <- genBoundedBytes(EncryptedMessageTransaction.NonceLength, EncryptedMessageTransaction.NonceLength)
+    fee <- positiveLongGen
+    timestamp <- positiveLongGen
+  } yield {
+    EncryptedMessageTransaction.create(timestamp, sender, recipient, fee, raw_message, nonce)
+  }
+
+  property("EncryptedMessageTransaction serialization roundtrip") {
+    forAll(rawEncryptedMessageGenerator) { issue: EncryptedMessageTransaction =>
+      val recovered = EncryptedMessageTransaction.parseBytes(issue.bytes).get
+      issue.validate shouldEqual ValidationResult.ValidateOke
+      recovered.validate shouldEqual ValidationResult.ValidateOke
+      recovered.bytes shouldEqual issue.bytes
+      issue.rawMessage shouldEqual recovered.rawMessage
+    }
+  }
+
+  val encryptedMessageGenerator: Gen[EncryptedMessageTransaction] = for {
+    sender: PrivateKeyAccount <- accountGen
+    recipient: PrivateKeyAccount <- accountGen
+    message <- genRandomMessage()
+    fee <- positiveLongGen
+    timestamp <- positiveLongGen
+  } yield {
+    EncryptedMessageTransaction.createAndEncrypt(timestamp, sender, recipient, fee, message)
+  }
+
+  property("EncryptedMessageTransaction key in wallet decryption") {
+    forAll(encryptedMessageGenerator) { issue: EncryptedMessageTransaction =>
+      val recovered = EncryptedMessageTransaction.parseBytes(issue.bytes).get
+      issue.validate shouldEqual ValidationResult.ValidateOke
+      recovered.validate shouldEqual ValidationResult.ValidateOke
+      recovered.bytes shouldEqual issue.bytes
+      issue.rawMessage shouldEqual recovered.rawMessage
+    }
+  }
+
+  property("EncryptedMessageTransaction known value encryption/decryption") {
+    val w = new Wallet(None, "cookies", Base58.decode("FQgbSAm6swGbtqA3NE8PttijPhT4N3Ufh4bHFAkyVnQz").toOption)
+    val known1 = w.generateNewAccount().get
+    val known2 = w.generateNewAccount().get
+    val unknown1 = new PrivateKeyAccount(Array[Byte](1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2))
+    val unknown2 = new PrivateKeyAccount(Array[Byte](5, 4, 3, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2))
+
+    val timestamp = 10293561
+    val fee = 19399541
+    val message = "What a beautiful message! I'm really jealous. :-)".getBytes()
+
+    var tx = EncryptedMessageTransaction.createAndEncrypt(timestamp, unknown1, unknown2, fee, message)
+    tx.decrypt(w).isDefined shouldEqual false
+    tx = EncryptedMessageTransaction.createAndEncrypt(timestamp, known1, known2, fee, message)
+    tx.decrypt(w).get shouldEqual message
+    tx = EncryptedMessageTransaction.createAndEncrypt(timestamp, unknown1, known2, fee, message)
+    tx.decrypt(w).get shouldEqual message
+    tx = EncryptedMessageTransaction.createAndEncrypt(timestamp, known1, unknown2, fee, message)
+    tx.decrypt(w).get shouldEqual message
+  }
+
+}

--- a/scorex-transaction/src/test/scala/scorex/transaction/MessageTransactionSpecification.scala
+++ b/scorex-transaction/src/test/scala/scorex/transaction/MessageTransactionSpecification.scala
@@ -1,0 +1,37 @@
+package scorex.transaction
+
+import org.scalatest._
+import org.scalatest.prop.PropertyChecks
+
+class MessageTransactionSpecification extends PropSpec with PropertyChecks with Matchers with TransactionGen {
+
+  property("MessageTransaction serialization roundtrip") {
+    forAll(messageGenerator) { issue: MessageTransaction =>
+      val recovered = MessageTransaction.parseBytes(issue.bytes).get
+      issue.validate shouldEqual ValidationResult.ValidateOke
+      recovered.validate shouldEqual ValidationResult.ValidateOke
+      recovered.bytes shouldEqual issue.bytes
+      issue.message shouldEqual recovered.message
+      issue.messageHash shouldEqual recovered.messageHash
+    }
+  }
+
+  property("MessageTransaction serialization from TypedTransaction") {
+    forAll(messageGenerator) { issue: MessageTransaction =>
+      val recovered = TypedTransaction.parseBytes(issue.bytes).get
+      issue.validate shouldEqual ValidationResult.ValidateOke
+      recovered.bytes shouldEqual issue.bytes
+      issue.messageHash shouldEqual recovered.asInstanceOf[MessageTransaction].messageHash
+    }
+  }
+
+  property("MessageTransaction validation fail") {
+    forAll(invalidMessageGenerator) { issue: MessageTransaction =>
+      val recovered = MessageTransaction.parseBytes(issue.bytes).get
+      issue.validate should not equal ValidationResult.ValidateOke
+      recovered.bytes shouldEqual issue.bytes
+      issue.messageHash shouldEqual recovered.messageHash
+    }
+  }
+
+}

--- a/scorex-transaction/src/test/scala/scorex/transaction/TransactionGen.scala
+++ b/scorex-transaction/src/test/scala/scorex/transaction/TransactionGen.scala
@@ -70,6 +70,26 @@ trait TransactionGen {
   val issueGenerator: Gen[IssueTransaction] = issueReissueGenerator.map(_._1)
   val reissueGenerator: Gen[ReissueTransaction] = issueReissueGenerator.map(_._3)
 
+  val messageGenerator: Gen[MessageTransaction] = for {
+    sender: PrivateKeyAccount <- accountGen
+    message <- genBoundedBytes(1, MessageTransaction.MaxMessageSize)
+    recipient: PrivateKeyAccount <- accountGen
+    fee <- positiveLongGen
+    timestamp <- positiveLongGen
+  } yield {
+    MessageTransaction.create(timestamp, sender, recipient, fee, message)
+  }
+
+  val invalidMessageGenerator: Gen[MessageTransaction] = for {
+    sender: PrivateKeyAccount <- accountGen
+    message <- genBoundedBytes(MessageTransaction.MaxMessageSize * 2, 1024)
+    recipient: PrivateKeyAccount <- accountGen
+    fee <- positiveLongGen
+    timestamp <- positiveLongGen
+  } yield {
+    MessageTransaction.create(timestamp, sender, recipient, fee, message)
+  }
+
   val invalidOrderGenerator: Gen[Order] = for {
     sender: PrivateKeyAccount <- accountGen
     matcher: PrivateKeyAccount <- accountGen


### PR DESCRIPTION
Changes: I've added transaction ID into the signature, an idea provided by tolsi's commit. :-)
https://github.com/wavesplatform/Scorex/pull/173

Size after pruning is:
159 bytes for unencrypted TX, 164 for an encrypted TX.
However, due to 1. Pruning being unimplemented and 2. The way the blocks are signed, it's impossible to prune them.
So size before pruning is: 161 + content AND about 180-190 + content for encrypted.
For pruning to become a possibility we need to change the way the blocks store transactions: Blocks shouldn't store transactions, they should store only their id's.
As for decryption, I added /transactions/decrypt/{signature} API. It requires an API_KEY and decrypts the message. Other than that, functionally it's identical to /transactions/info/{signature}.